### PR TITLE
Create activity API endpoints for backend with CRUD and roles

### DIFF
--- a/backend/activities/admin.py
+++ b/backend/activities/admin.py
@@ -45,17 +45,11 @@ class ActivityAdminForm(forms.ModelForm):
             # Combine: top-level options first, then grouped sections
             self.fields['categories'].choices = top_level_options + grouped_choices
         else:
-            allowed = getattr(
-                settings,
-                'ACTIVITY_ALLOWED_CATEGORIES',
-                [
-                    'กิจกรรมมหาวิทยาลัย',
-                    'เสริมสร้างสมรรถนะ',
-                    'เพื่อสังคม',
-                    'อื่นๆ',
-                ],
+            # No fallback: model only accepts categories from ACTIVITY_CATEGORY_GROUPS
+            self.fields['categories'].choices = []
+            self.fields['categories'].help_text = (
+                'No categories configured. Please set ACTIVITY_CATEGORY_GROUPS in settings.'
             )
-            self.fields['categories'].choices = [(c, c) for c in allowed]
         # If instance exists, prefill
         if self.instance and isinstance(self.instance.categories, list):
             self.initial['categories'] = self.instance.categories

--- a/backend/activities/admin.py
+++ b/backend/activities/admin.py
@@ -1,0 +1,28 @@
+from django.contrib import admin
+from django import forms
+from .models import Activity
+from users.models import User
+
+
+class OrganizerChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj: User) -> str:
+        org_name = getattr(getattr(obj, 'organizer_profile', None), 'organization_name', None)
+        return org_name or obj.email
+
+
+class ActivityAdminForm(forms.ModelForm):
+    organizer = OrganizerChoiceField(
+        queryset=User.objects.filter(role='organizer').select_related('organizer_profile')
+    )
+
+    class Meta:
+        model = Activity
+        fields = '__all__'
+
+
+@admin.register(Activity)
+class ActivityAdmin(admin.ModelAdmin):
+    form = ActivityAdminForm
+    list_display = ('id', 'title', 'organizer', 'status', 'start_at', 'end_at', 'created_at')
+    list_filter = ('status', 'start_at', 'end_at', 'created_at')
+    search_fields = ('title', 'description', 'location', 'organizer__email')

--- a/backend/activities/admin.py
+++ b/backend/activities/admin.py
@@ -6,14 +6,12 @@ from users.models import User
 
 class OrganizerChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj: User) -> str:
-        org_name = getattr(getattr(obj, 'organizer_profile', None), 'organization_name', None)
-        return org_name or obj.email
+        fullname = f"{(obj.first_name or '').strip()} {(obj.last_name or '').strip()}".strip()
+        return fullname or obj.email
 
 
 class ActivityAdminForm(forms.ModelForm):
-    organizer = OrganizerChoiceField(
-        queryset=User.objects.filter(role='organizer').select_related('organizer_profile')
-    )
+    organizer = OrganizerChoiceField(queryset=User.objects.filter(role='organizer'))
 
     class Meta:
         model = Activity

--- a/backend/activities/admin.py
+++ b/backend/activities/admin.py
@@ -66,7 +66,7 @@ class ActivityAdminForm(forms.ModelForm):
 @admin.register(Activity)
 class ActivityAdmin(admin.ModelAdmin):
     form = ActivityAdminForm
-    list_display = ('id', 'title', 'get_organizer_name', 'status', 'start_at', 'end_at', 'created_at')
+    list_display = ('id', 'title', 'get_organizer_name', 'status', 'current_participants', 'max_participants', 'start_at', 'end_at', 'created_at')
     list_filter = ('status', 'start_at', 'end_at', 'created_at')
     search_fields = (
         'title', 'description', 'location',
@@ -86,7 +86,7 @@ class ActivityAdmin(admin.ModelAdmin):
             'fields': ('start_at', 'end_at')
         }),
         ('Capacity & status', {
-            'fields': ('max_participants', 'hours_awarded', 'status')
+            'fields': ('max_participants', 'current_participants', 'hours_awarded', 'status')
         }),
         ('Metadata', {
             'classes': ('collapse',),

--- a/backend/activities/apps.py
+++ b/backend/activities/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ActivitiesConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'activities'

--- a/backend/activities/models.py
+++ b/backend/activities/models.py
@@ -1,0 +1,117 @@
+from django.db import models
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import MinValueValidator
+from django.utils import timezone
+
+
+class Activity(models.Model):
+    class Status(models.TextChoices):
+        PENDING = 'pending', 'Pending'  # admin only
+        OPEN = 'open', 'Open'
+        FULL = 'full', 'Full'
+        CLOSED = 'closed', 'Closed'
+        CANCELLED = 'cancelled', 'Cancelled'
+
+    def _validate_categories(value):
+        """Validate categories: non-empty list up to 4 items and each within allowed set.
+
+        Allowed categories can be configured via settings.ACTIVITY_ALLOWED_CATEGORIES.
+        """
+        if value is None:
+            return
+        if not isinstance(value, list):
+            raise ValidationError('categories must be a list of strings (1-4).')
+        if not (1 <= len(value) <= 4):
+            raise ValidationError('categories must have between 1 and 4 items.')
+        if not all(isinstance(i, str) and i.strip() for i in value):
+            raise ValidationError('each category must be a non-empty string.')
+        allowed = getattr(
+            settings,
+            'ACTIVITY_ALLOWED_CATEGORIES',
+            [
+                'กิจกรรมมหาวิทยาลัย',
+                'เสริมสร้างสมรรถนะ',
+                'เพื่อสังคม',
+                'อื่นๆ',
+            ],
+        )
+        invalid = [c for c in value if c not in allowed]
+        if invalid:
+            raise ValidationError(f"invalid category(ies): {invalid}. Allowed: {allowed}")
+
+    organizer = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='activities'
+    )
+    categories = models.JSONField(default=list, blank=True, validators=[_validate_categories])
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True)
+    start_at = models.DateTimeField()
+    end_at = models.DateTimeField()
+    location = models.CharField(max_length=255, blank=True)
+    max_participants = models.PositiveIntegerField(null=True, blank=True)
+    current_participants = models.PositiveIntegerField(default=0)
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.PENDING)
+    hours_awarded = models.DecimalField(max_digits=5, decimal_places=2, null=True, blank=True, validators=[MinValueValidator(0)])
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    # Organizer deletion request workflow: if current_participants > 0, organizer must request admin approval
+    deletion_requested = models.BooleanField(default=False)
+    deletion_reason = models.TextField(blank=True, null=True)
+    deletion_requested_at = models.DateTimeField(blank=True, null=True)
+    deletion_requested_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='activity_deletion_requests',
+    )
+
+    def __str__(self):
+        return f"{self.title} ({self.get_status_display()})"
+
+    # ----- Business rules helpers -----
+    @property
+    def requires_admin_for_delete(self) -> bool:
+        """Return True when organizer needs admin approval to delete (>= 1 participant)."""
+        return (self.current_participants or 0) > 0
+
+    def can_be_deleted_by(self, user) -> bool:
+        """Admins can always delete. Organizer may delete only when no participants signed up.
+
+        Note: This does not perform deletion; use in views/services to gate delete actions.
+        """
+        if user is None:
+            return False
+        # Admins can delete anytime
+        if getattr(user, 'role', None) == 'admin' or getattr(user, 'is_superuser', False):
+            return True
+        # Organizer can delete only own activity and when zero participants
+        if getattr(user, 'role', None) == 'organizer' and user == self.organizer:
+            return self.current_participants == 0
+        return False
+
+    def request_deletion(self, user, reason: str | None = None):
+        """Mark this activity as having a deletion request by an organizer with a reason.
+
+        Intended for the case: current_participants >= 1 so organizer cannot hard-delete without admin.
+        """
+        # Preconditions
+        if not self.requires_admin_for_delete:
+            # No need to request deletion; organizer can delete directly when participants are zero
+            raise ValidationError("Deletion request not required: no participants; delete is allowed.")
+        if self.deletion_requested:
+            raise ValidationError("Deletion has already been requested for this activity.")
+        if not reason or not str(reason).strip():
+            raise ValidationError({"deletion_reason": "Reason is required when requesting deletion."})
+
+        self.deletion_requested = True
+        self.deletion_reason = str(reason).strip()
+        self.deletion_requested_at = timezone.now()
+        self.deletion_requested_by = user if user and getattr(user, 'role', None) == 'organizer' else None
+        self.save(update_fields=[
+            'deletion_requested', 'deletion_reason', 'deletion_requested_at', 'deletion_requested_by'
+        ])

--- a/backend/activities/models.py
+++ b/backend/activities/models.py
@@ -82,6 +82,16 @@ class Activity(models.Model):
             requested_by=user,
         )
 
+    @property
+    def capacity_reached(self) -> bool:
+        """Return True if current_participants has reached or exceeded max_participants.
+        When max_participants is None, capacity is considered not reached.
+        """
+        if self.max_participants is None:
+            return False
+        return (self.current_participants or 0) >= self.max_participants
+
+
 
 class ActivityDeletionRequest(models.Model):
     class Status(models.TextChoices):

--- a/backend/activities/serializers.py
+++ b/backend/activities/serializers.py
@@ -1,22 +1,23 @@
 from rest_framework import serializers
-from .models import Activity
+from .models import Activity, ActivityDeletionRequest
 
 
 class ActivitySerializer(serializers.ModelSerializer):
     requires_admin_for_delete = serializers.BooleanField(read_only=True)
-    organizer_email = serializers.EmailField(source='organizer.email', read_only=True)
+    organizer_profile_id = serializers.IntegerField(source='organizer_profile.id', read_only=True)
+    organizer_email = serializers.EmailField(source='organizer_profile.user.email', read_only=True)
+    organizer_name = serializers.CharField(source='organizer_profile.organization_name', read_only=True)
 
     class Meta:
         model = Activity
         fields = [
-            'id', 'organizer', 'organizer_email', 'categories', 'title', 'description',
+            'id', 'organizer_profile_id', 'organizer_email', 'organizer_name', 'categories', 'title', 'description',
             'start_at', 'end_at', 'location', 'max_participants', 'current_participants',
-            'status', 'hours_awarded', 'created_at', 'updated_at',
-            'requires_admin_for_delete', 'deletion_requested', 'deletion_reason',
+            'status', 'hours_awarded', 'created_at', 'updated_at', 'requires_admin_for_delete',
         ]
         read_only_fields = [
-            'id', 'organizer', 'organizer_email', 'current_participants', 'status',
-            'created_at', 'updated_at', 'requires_admin_for_delete', 'deletion_requested', 'deletion_reason'
+            'id', 'organizer_profile_id', 'organizer_email', 'organizer_name', 'current_participants', 'status',
+            'created_at', 'updated_at', 'requires_admin_for_delete'
         ]
 
 
@@ -31,5 +32,18 @@ class ActivityWriteSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         request = self.context.get('request')
         user = getattr(request, 'user', None)
-        # organizer set from the authenticated user
-        return Activity.objects.create(organizer=user, **validated_data)
+        organizer_profile = getattr(user, 'organizer_profile', None)
+        return Activity.objects.create(organizer_profile=organizer_profile, **validated_data)
+
+
+class ActivityDeletionRequestSerializer(serializers.ModelSerializer):
+    activity_title = serializers.CharField(source='activity.title', read_only=True)
+    requested_by_email = serializers.EmailField(source='requested_by.email', read_only=True)
+
+    class Meta:
+        model = ActivityDeletionRequest
+        fields = [
+            'id', 'activity', 'activity_title', 'reason', 'status', 'requested_by', 'requested_by_email',
+            'requested_at', 'reviewed_by', 'reviewed_at', 'review_note'
+        ]
+        read_only_fields = ['status', 'requested_at', 'reviewed_by', 'reviewed_at']

--- a/backend/activities/serializers.py
+++ b/backend/activities/serializers.py
@@ -4,6 +4,7 @@ from .models import Activity, ActivityDeletionRequest
 
 class ActivitySerializer(serializers.ModelSerializer):
     requires_admin_for_delete = serializers.BooleanField(read_only=True)
+    capacity_reached = serializers.BooleanField(read_only=True)
     organizer_profile_id = serializers.IntegerField(source='organizer_profile.id', read_only=True)
     organizer_email = serializers.EmailField(source='organizer_profile.user.email', read_only=True)
     organizer_name = serializers.CharField(source='organizer_profile.organization_name', read_only=True)
@@ -13,11 +14,11 @@ class ActivitySerializer(serializers.ModelSerializer):
         fields = [
             'id', 'organizer_profile_id', 'organizer_email', 'organizer_name', 'categories', 'title', 'description',
             'start_at', 'end_at', 'location', 'max_participants', 'current_participants',
-            'status', 'hours_awarded', 'created_at', 'updated_at', 'requires_admin_for_delete',
+            'status', 'hours_awarded', 'created_at', 'updated_at', 'requires_admin_for_delete', 'capacity_reached',
         ]
         read_only_fields = [
             'id', 'organizer_profile_id', 'organizer_email', 'organizer_name', 'current_participants', 'status',
-            'created_at', 'updated_at', 'requires_admin_for_delete'
+            'created_at', 'updated_at', 'requires_admin_for_delete', 'capacity_reached'
         ]
 
 
@@ -47,3 +48,5 @@ class ActivityDeletionRequestSerializer(serializers.ModelSerializer):
             'requested_at', 'reviewed_by', 'reviewed_at', 'review_note'
         ]
         read_only_fields = ['status', 'requested_at', 'reviewed_by', 'reviewed_at']
+
+

--- a/backend/activities/serializers.py
+++ b/backend/activities/serializers.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+from .models import Activity
+
+
+class ActivitySerializer(serializers.ModelSerializer):
+    requires_admin_for_delete = serializers.BooleanField(read_only=True)
+    organizer_email = serializers.EmailField(source='organizer.email', read_only=True)
+
+    class Meta:
+        model = Activity
+        fields = [
+            'id', 'organizer', 'organizer_email', 'categories', 'title', 'description',
+            'start_at', 'end_at', 'location', 'max_participants', 'current_participants',
+            'status', 'hours_awarded', 'created_at', 'updated_at',
+            'requires_admin_for_delete', 'deletion_requested', 'deletion_reason',
+        ]
+        read_only_fields = [
+            'id', 'organizer', 'organizer_email', 'current_participants', 'status',
+            'created_at', 'updated_at', 'requires_admin_for_delete', 'deletion_requested', 'deletion_reason'
+        ]
+
+
+class ActivityWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Activity
+        fields = [
+            'categories', 'title', 'description', 'start_at', 'end_at', 'location',
+            'max_participants', 'hours_awarded'
+        ]
+
+    def create(self, validated_data):
+        request = self.context.get('request')
+        user = getattr(request, 'user', None)
+        # organizer set from the authenticated user
+        return Activity.objects.create(organizer=user, **validated_data)

--- a/backend/activities/urls.py
+++ b/backend/activities/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+from .views import (
+    ActivityListCreateView,
+    ActivityRetrieveUpdateView,
+    ActivityDeleteView,
+    ActivityRequestDeleteView,
+)
+
+
+urlpatterns = [
+    path('', ActivityListCreateView.as_view(), name='activity-list-create'),
+    path('<int:pk>/', ActivityRetrieveUpdateView.as_view(), name='activity-detail'),
+    path('<int:pk>/delete/', ActivityDeleteView.as_view(), name='activity-delete'),
+    path('<int:pk>/request-delete/', ActivityRequestDeleteView.as_view(), name='activity-request-delete'),
+]

--- a/backend/activities/urls.py
+++ b/backend/activities/urls.py
@@ -4,6 +4,9 @@ from .views import (
     ActivityRetrieveUpdateView,
     ActivityDeleteView,
     ActivityRequestDeleteView,
+    ActivityDeletionRequestListView,
+    ActivityDeletionRequestReviewView,
+    ActivityMetadataView,
 )
 
 
@@ -12,4 +15,7 @@ urlpatterns = [
     path('<int:pk>/', ActivityRetrieveUpdateView.as_view(), name='activity-detail'),
     path('<int:pk>/delete/', ActivityDeleteView.as_view(), name='activity-delete'),
     path('<int:pk>/request-delete/', ActivityRequestDeleteView.as_view(), name='activity-request-delete'),
+    path('deletion-requests/', ActivityDeletionRequestListView.as_view(), name='activity-deletion-request-list'),
+    path('deletion-requests/<int:pk>/review/', ActivityDeletionRequestReviewView.as_view(), name='activity-deletion-request-review'),
+    path('metadata/', ActivityMetadataView.as_view(), name='activity-metadata'),
 ]

--- a/backend/activities/urls.py
+++ b/backend/activities/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 from .views import (
-    ActivityListCreateView,
-    ActivityRetrieveUpdateView,
+    ActivityListOnlyView,
+    ActivityCreateOnlyView,
+    ActivityDetailOnlyView,
+    ActivityUpdateOnlyView,
     ActivityDeleteView,
     ActivityRequestDeleteView,
     ActivityDeletionRequestListView,
@@ -11,11 +13,16 @@ from .views import (
 
 
 urlpatterns = [
-    path('', ActivityListCreateView.as_view(), name='activity-list-create'),
-    path('<int:pk>/', ActivityRetrieveUpdateView.as_view(), name='activity-detail'),
-    path('<int:pk>/delete/', ActivityDeleteView.as_view(), name='activity-delete'),
-    path('<int:pk>/request-delete/', ActivityRequestDeleteView.as_view(), name='activity-request-delete'),
+    # CRUD-like paths mirroring users URL style
+    path('list/', ActivityListOnlyView.as_view(), name='activity-list'),
+    path('create/', ActivityCreateOnlyView.as_view(), name='activity-create'),
+    path('<int:pk>/', ActivityDetailOnlyView.as_view(), name='activity-detail'),
+    path('<int:pk>/update/', ActivityUpdateOnlyView.as_view(), name='activity-update'),
+    path('delete/<int:pk>/', ActivityDeleteView.as_view(), name='activity-delete'),
+    # Deletion request workflow (admin moderation)
+    path('request-delete/<int:pk>/', ActivityRequestDeleteView.as_view(), name='activity-request-delete'),
     path('deletion-requests/', ActivityDeletionRequestListView.as_view(), name='activity-deletion-request-list'),
     path('deletion-requests/<int:pk>/review/', ActivityDeletionRequestReviewView.as_view(), name='activity-deletion-request-review'),
+    # Metadata for categories
     path('metadata/', ActivityMetadataView.as_view(), name='activity-metadata'),
 ]

--- a/backend/activities/views.py
+++ b/backend/activities/views.py
@@ -1,0 +1,103 @@
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from django.shortcuts import get_object_or_404
+from .models import Activity
+from .serializers import ActivitySerializer, ActivityWriteSerializer
+
+
+class IsOrganizer(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated and getattr(request.user, 'role', None) == 'organizer'
+
+
+class IsAdmin(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated and (
+            getattr(request.user, 'role', None) == 'admin' or getattr(request.user, 'is_superuser', False)
+        )
+
+
+class ActivityListCreateView(generics.ListCreateAPIView):
+    queryset = Activity.objects.all().select_related('organizer')
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return ActivityWriteSerializer
+        return ActivitySerializer
+
+    def perform_create(self, serializer):
+        # Only organizers create activities
+        if getattr(self.request.user, 'role', None) != 'organizer':
+            self.permission_denied(self.request, message='Only organizers can create activities')
+        serializer.save()
+
+    def get_queryset(self):
+        user = self.request.user
+        if getattr(user, 'role', None) == 'organizer':
+            return self.queryset.filter(organizer=user)
+        if getattr(user, 'role', None) == 'admin' or user.is_superuser:
+            return self.queryset
+        # Students see open activities only (optional, can be adjusted later)
+        return self.queryset.filter(status=Activity.Status.OPEN)
+
+
+class ActivityRetrieveUpdateView(generics.RetrieveUpdateAPIView):
+    queryset = Activity.objects.all().select_related('organizer')
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.request.method in ('PUT', 'PATCH'):
+            return ActivityWriteSerializer
+        return ActivitySerializer
+
+    def perform_update(self, serializer):
+        instance: Activity = self.get_object()
+        user = self.request.user
+        if getattr(user, 'role', None) == 'organizer' and instance.organizer != user:
+            self.permission_denied(self.request, message='Not your activity')
+        serializer.save()
+
+
+class ActivityDeleteView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request, pk: int):
+        activity = get_object_or_404(Activity, pk=pk)
+        user = request.user
+        # Admin can always delete
+        if getattr(user, 'role', None) == 'admin' or user.is_superuser:
+            activity.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        # Organizer deletion rules
+        if getattr(user, 'role', None) != 'organizer' or activity.organizer != user:
+            return Response({'detail': 'Not allowed'}, status=status.HTTP_403_FORBIDDEN)
+
+        if activity.current_participants == 0:
+            activity.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        # If participants >= 1, require deletion request
+        return Response({
+            'detail': 'Participants exist; deletion requires admin approval',
+            'requires_admin_for_delete': True
+        }, status=status.HTTP_409_CONFLICT)
+
+
+class ActivityRequestDeleteView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, pk: int):
+        activity = get_object_or_404(Activity, pk=pk)
+        user = request.user
+        if getattr(user, 'role', None) != 'organizer' or activity.organizer != user:
+            return Response({'detail': 'Not allowed'}, status=status.HTTP_403_FORBIDDEN)
+
+        reason = request.data.get('reason')
+        try:
+            activity.request_deletion(user, reason)
+        except Exception as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(ActivitySerializer(activity).data, status=status.HTTP_200_OK)

--- a/backend/activities/views.py
+++ b/backend/activities/views.py
@@ -1,101 +1,130 @@
+from typing import Any
+
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from rest_framework import generics, permissions, status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from django.shortcuts import get_object_or_404
+
+from config.constants import ActivityStatus, StatusMessages, UserRoles
+from config.permissions import IsAdmin, IsOrganizer
+from config.utils import get_activity_category_groups, is_admin_user
 from .models import Activity, ActivityDeletionRequest
 from .serializers import (
+    ActivityDeletionRequestSerializer,
     ActivitySerializer,
     ActivityWriteSerializer,
-    ActivityDeletionRequestSerializer,
 )
-from django.utils import timezone
-from django.conf import settings
-
-
-class IsOrganizer(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated and getattr(request.user, 'role', None) == 'organizer'
-
-
-class IsAdmin(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return request.user and request.user.is_authenticated and (
-            getattr(request.user, 'role', None) == 'admin' or getattr(request.user, 'is_superuser', False)
-        )
 
 
 class ActivityListCreateView(generics.ListCreateAPIView):
+    """API view for listing and creating activities."""
+    
     queryset = Activity.objects.all().select_related('organizer_profile', 'organizer_profile__user')
     permission_classes = [permissions.IsAuthenticated]
 
     def get_serializer_class(self):
+        """Return appropriate serializer based on request method."""
         if self.request.method == 'POST':
             return ActivityWriteSerializer
         return ActivitySerializer
 
-    def perform_create(self, serializer):
-        # Organizers and admins can create activities
-        if getattr(self.request.user, 'role', None) not in ('organizer', 'admin') and not self.request.user.is_superuser:
-            self.permission_denied(self.request, message='Only organizers or admins can create activities')
+    def perform_create(self, serializer: ActivityWriteSerializer) -> None:
+        """Create activity with proper authorization."""
+        user = self.request.user
+        user_role = getattr(user, 'role', None)
+        
+        if user_role not in (UserRoles.ORGANIZER, UserRoles.ADMIN) and not user.is_superuser:
+            self.permission_denied(
+                self.request, 
+                message='Only organizers or admins can create activities'
+            )
         serializer.save()
 
     def get_queryset(self):
+        """Filter queryset based on user role."""
         user = self.request.user
-        if getattr(user, 'role', None) == 'organizer':
-            return self.queryset.all().filter(organizer_profile__user=user)
-        if getattr(user, 'role', None) == 'admin' or user.is_superuser:
+        user_role = getattr(user, 'role', None)
+        
+        if user_role == UserRoles.ORGANIZER:
+            return self.queryset.filter(organizer_profile__user=user)
+        if is_admin_user(user):
             return self.queryset.all()
         # Students: see all activities except pending
-        return self.queryset.all().exclude(status=Activity.Status.PENDING)
+        return self.queryset.exclude(status=ActivityStatus.PENDING)
 
 
 class ActivityListOnlyView(ActivityListCreateView):
+    """API view for listing activities only."""
     http_method_names = ['get']
 
 
 class ActivityCreateOnlyView(ActivityListCreateView):
+    """API view for creating activities only."""
     http_method_names = ['post']
 
 
 class ActivityRetrieveUpdateView(generics.RetrieveUpdateAPIView):
+    """API view for retrieving and updating activities."""
+    
     queryset = Activity.objects.all().select_related('organizer_profile', 'organizer_profile__user')
     permission_classes = [permissions.IsAuthenticated]
 
     def get_serializer_class(self):
+        """Return appropriate serializer based on request method."""
         if self.request.method in ('PUT', 'PATCH'):
             return ActivityWriteSerializer
         return ActivitySerializer
 
-    def perform_update(self, serializer):
+    def perform_update(self, serializer: ActivityWriteSerializer) -> None:
+        """Update activity with proper authorization."""
         instance: Activity = self.get_object()
         user = self.request.user
-        if getattr(user, 'role', None) == 'organizer' and instance.organizer_profile.user != user:
-            self.permission_denied(self.request, message='Not your activity')
+        user_role = getattr(user, 'role', None)
+        
+        if (user_role == UserRoles.ORGANIZER and 
+            instance.organizer_profile.user != user):
+            self.permission_denied(
+                self.request, 
+                message=StatusMessages.NOT_YOUR_ACTIVITY
+            )
         serializer.save()
 
 
 class ActivityDetailOnlyView(ActivityRetrieveUpdateView):
+    """API view for retrieving activity details only."""
     http_method_names = ['get']
 
 
 class ActivityUpdateOnlyView(ActivityRetrieveUpdateView):
+    """API view for updating activities only."""
     http_method_names = ['put', 'patch']
 
 
 class ActivityDeleteView(APIView):
+    """API view for deleting activities."""
+    
     permission_classes = [permissions.IsAuthenticated]
 
-    def delete(self, request, pk: int):
+    def delete(self, request: Request, pk: int) -> Response:
+        """Delete activity with proper authorization and business rules."""
         activity = get_object_or_404(Activity, pk=pk)
         user = request.user
+        user_role = getattr(user, 'role', None)
+        
         # Admin can always delete
-        if getattr(user, 'role', None) == 'admin' or user.is_superuser:
+        if is_admin_user(user):
             activity.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         # Organizer deletion rules
-        if getattr(user, 'role', None) != 'organizer' or activity.organizer_profile.user != user:
-            return Response({'detail': 'Not allowed'}, status=status.HTTP_403_FORBIDDEN)
+        if (user_role != UserRoles.ORGANIZER or 
+            activity.organizer_profile.user != user):
+            return Response(
+                {'detail': StatusMessages.PERMISSION_DENIED}, 
+                status=status.HTTP_403_FORBIDDEN
+            )
 
         if activity.current_participants == 0:
             activity.delete()
@@ -103,65 +132,104 @@ class ActivityDeleteView(APIView):
 
         # If participants >= 1, require deletion request
         return Response({
-            'detail': 'Participants exist; deletion requires admin approval',
+            'detail': StatusMessages.DELETION_REQUIRES_ADMIN,
             'requires_admin_for_delete': True
         }, status=status.HTTP_409_CONFLICT)
 
 
 class ActivityRequestDeleteView(APIView):
+    """API view for requesting activity deletion."""
+    
     permission_classes = [permissions.IsAuthenticated]
 
-    def post(self, request, pk: int):
+    def post(self, request: Request, pk: int) -> Response:
+        """Create a deletion request for an activity."""
         activity = get_object_or_404(Activity, pk=pk)
         user = request.user
-        if getattr(user, 'role', None) != 'organizer' or activity.organizer_profile.user != user:
-            return Response({'detail': 'Not allowed'}, status=status.HTTP_403_FORBIDDEN)
+        user_role = getattr(user, 'role', None)
+        
+        if (user_role != UserRoles.ORGANIZER or 
+            activity.organizer_profile.user != user):
+            return Response(
+                {'detail': StatusMessages.PERMISSION_DENIED}, 
+                status=status.HTTP_403_FORBIDDEN
+            )
 
         reason = request.data.get('reason')
         try:
-            req = activity.request_deletion(user, reason)
+            deletion_request = activity.request_deletion(user, reason)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        return Response(ActivityDeletionRequestSerializer(req).data, status=status.HTTP_201_CREATED)
+            return Response(
+                {'detail': str(e)}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        return Response(
+            ActivityDeletionRequestSerializer(deletion_request).data, 
+            status=status.HTTP_201_CREATED
+        )
 
 
 class ActivityDeletionRequestListView(generics.ListAPIView):
+    """API view for listing activity deletion requests (admin only)."""
+    
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
     queryset = ActivityDeletionRequest.objects.select_related('activity', 'requested_by')
     serializer_class = ActivityDeletionRequestSerializer
 
 
 class ActivityDeletionRequestReviewView(APIView):
+    """API view for reviewing activity deletion requests (admin only)."""
+    
     permission_classes = [permissions.IsAuthenticated, IsAdmin]
 
-    def post(self, request, pk: int):
-        req = get_object_or_404(ActivityDeletionRequest, pk=pk)
+    def post(self, request: Request, pk: int) -> Response:
+        """Review (approve or reject) a deletion request."""
+        deletion_request = get_object_or_404(ActivityDeletionRequest, pk=pk)
         action = request.data.get('action')  # 'approve' or 'reject'
         note = request.data.get('note', '')
+        
         if action not in ('approve', 'reject'):
-            return Response({'detail': 'Invalid action'}, status=status.HTTP_400_BAD_REQUEST)
-        req.status = 'approved' if action == 'approve' else 'rejected'
-        req.review_note = note
-        req.reviewed_by = request.user
-        req.reviewed_at = timezone.now()
-        req.save(update_fields=['status', 'review_note', 'reviewed_by', 'reviewed_at'])
-        return Response(ActivityDeletionRequestSerializer(req).data)
+            return Response(
+                {'detail': StatusMessages.INVALID_ACTION}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        if action == 'approve':
+            deletion_request.approve(request.user, note)
+        else:
+            deletion_request.reject(request.user, note)
+        
+        return Response(ActivityDeletionRequestSerializer(deletion_request).data)
 
 
 class ActivityMetadataView(APIView):
+    """API view for activity metadata (categories, etc.)."""
+    
     permission_classes = [permissions.AllowAny]
 
-    def get(self, request):
-        groups = getattr(settings, 'ACTIVITY_CATEGORY_GROUPS', None)
+    def get(self, request: Request) -> Response:
+        """Return activity category configuration and metadata."""
+        groups = get_activity_category_groups()
+        
         if groups and isinstance(groups, dict):
             # Header-only groups (empty list) are selectable top-level categories
-            top_levels = [name for name, items in groups.items() if isinstance(items, (list, tuple)) and not items]
+            top_levels = [
+                name for name, items in groups.items() 
+                if isinstance(items, (list, tuple)) and not items
+            ]
             # Non-empty groups are compound categories with sub-items
-            compound = [name for name, items in groups.items() if isinstance(items, (list, tuple)) and items]
-            subcategories = {name: list(items) for name, items in groups.items() if name in compound}
+            compound = [
+                name for name, items in groups.items() 
+                if isinstance(items, (list, tuple)) and items
+            ]
+            subcategories = {
+                name: list(items) for name, items in groups.items() 
+                if name in compound
+            }
             payload = {
-                'top_levels': top_levels + compound,  # include umbrella names themselves for first-level selection
-                'compound_categories': compound,       # these require choosing from subcategories on the UI
+                'top_levels': top_levels + compound,  # include umbrella names for selection
+                'compound_categories': compound,       # require choosing from subcategories
                 'subcategories': subcategories,        
                 'categories_max': 4,
             }

--- a/backend/config/pagination.py
+++ b/backend/config/pagination.py
@@ -1,0 +1,13 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class NoPrevNextPagination(PageNumberPagination):
+    """PageNumberPagination that returns only count and results."""
+    page_size = 20
+
+    def get_paginated_response(self, data):
+        return Response({
+            'count': self.page.paginator.count,
+            'results': data,
+        })

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'users',
     'social_django',
+    'activities',
 ]
 
 REST_FRAMEWORK = {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -59,7 +59,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'config.pagination.NoPrevNextPagination',  # use custom paginator (count + results only)
     'PAGE_SIZE': 20,
 }
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -13,6 +13,7 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("api/users/", include("users.urls")),
+    path("api/activities/", include("activities.urls")),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/auth/', include('social_django.urls', namespace='social')),

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -3,6 +3,9 @@ from .models import User, StudentProfile, OrganizerProfile
 
 
 class StudentProfileSerializer(serializers.ModelSerializer):
+    # Map API field name 'graduation_year' to model field 'year' for compatibility with main branch
+    graduation_year = serializers.IntegerField(source="year", required=False, allow_null=True)
+
     class Meta:
         model = StudentProfile
         fields = ["student_id_external", "year", "faculty", "major"]

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -3,9 +3,6 @@ from .models import User, StudentProfile, OrganizerProfile
 
 
 class StudentProfileSerializer(serializers.ModelSerializer):
-    # Map API field name 'graduation_year' to model field 'year' for compatibility with main branch
-    graduation_year = serializers.IntegerField(source="year", required=False, allow_null=True)
-
     class Meta:
         model = StudentProfile
         fields = ["student_id_external", "year", "faculty", "major"]


### PR DESCRIPTION
## Description  
This PR aligns **organizer permissions** and **admin UX** with organization workflows.  
Organizers now see and manage **all activities under their organization** (e.g., *Faculty of Engineering*), not just those they personally created.  
Deletion requests are enforced when participants exist, and **Django Admin** gains improved categories, capacity, and review actions UX.

---

## What Changed  

### Organizer Permissions & Visibility
- Organizer activity lists now include **all activities under their organization**.
- `retrieve/update/delete/request-delete` actions validate **organization membership** (not just creator).

### Deletion-Request Workflow
- `current_participants == 0` → direct delete allowed.  
- `current_participants > 0` → `409 Conflict`; organizer must create a **deletion request** for admin review.  

### Django Admin Improvements
- **Activity admin**:  
  - Shows/edits `current_participants`, `max_participants`, `hours_awarded`, and `status`.  
  - Categories rendered with grouped choices via `ACTIVITY_CATEGORY_GROUPS` (empty groups selectable as headers).  
  - Organizer dropdown shows **organization names** (not emails), de-duplicated with `distinct("organization_name")`.  
- **DeletionRequest admin**:  
  - Bulk `approve/reject` actions.  
  - Clearer list display.  

### Defaults & Validation
- Activity categories limited to **max 4** selections.  
- `current_participants` defaults to **0** (no need to set manually).  

---

## Checklists
- [x]  Admin can see all activities
- [x] Admin can delete activity
- [x] Admin can update activity
- [x] Admin can create activity
- [x] Organizer can create activity
- [x] Organizer can see all activity under their own organization name
- [x] Organizer can delete activity if participant == 0
- [x] Organization can not delete activity if participant >= 1 so they need to pending delete request
- [x] Organization can update activity under their own organization name
- [x] Student can see all activity that status is not 'pending'

---

## Screenshot

- Organizer try to delete the event tht at have >= 1 participant

<img width="942" height="950" alt="Screenshot 2568-10-02 at 09 49 51" src="https://github.com/user-attachments/assets/d4545cca-7894-4c9c-9e53-152de78bc229" />

- Organizer send delete request to admin

<img width="931" height="942" alt="Screenshot 2568-10-02 at 09 50 32" src="https://github.com/user-attachments/assets/5bbdf2c0-7d74-4bec-878b-3d3ef9a48368" />

- Organizer see activity

<img width="811" height="460" alt="Screenshot 2568-10-02 at 09 56 39" src="https://github.com/user-attachments/assets/3cc741be-cbbd-4e09-a32c-73f2df2bd65f" />

- Organizer that under same organizer name delete the activity that participant = 0 that have create under same organizer name

<img width="817" height="909" alt="Screenshot 2568-10-02 at 09 56 46" src="https://github.com/user-attachments/assets/9a8ad847-d603-4ad9-904a-7f8be8877f6c" />

- Student see will not see pending status after look in all event

<img width="927" height="946" alt="Screenshot 2568-10-02 at 09 57 06" src="https://github.com/user-attachments/assets/73ad0e4e-6af6-4372-a310-087826fce556" />

- Organization can create activity

<img width="869" height="975" alt="Screenshot 2568-10-02 at 00 12 14" src="https://github.com/user-attachments/assets/77aa3a58-02d4-452c-9290-8a2b5a533367" />

- When Other Organizer try to delete Activity event that not created under the same Organize name

<img width="820" height="897" alt="Screenshot 2568-10-02 at 00 13 58" src="https://github.com/user-attachments/assets/9757bebe-ce94-4bd3-a84b-81d5b81dd87e" />


- Student try to create activity

<img width="940" height="1018" alt="Screenshot 2568-10-02 at 00 18 08" src="https://github.com/user-attachments/assets/e7d410ac-5ea4-42f2-b189-8dba6f1616e3" />

- Student try to delete activity

<img width="941" height="1030" alt="Screenshot 2568-10-02 at 00 18 28" src="https://github.com/user-attachments/assets/a862a844-4562-4581-949e-103fc9169a14" />


---

## Backend Changes  

### `admin.py`
- Custom `OrganizerProfileChoiceField` → labels show organization names.  
- `ActivityAdminForm`:  
  - Categories as `MultipleChoiceField` with `CheckboxSelectMultiple`.  
  - Groups & header-only handling from `settings.ACTIVITY_CATEGORY_GROUPS`.  
  - Enforces **max 4 selections**.  
- `ActivityAdmin`:  
  - `list_display` includes `current_participants`, `max_participants`.  
  - Read-only: `created_at`, `updated_at`.  
  - Search across: `title`, `description`, `location`, organizer org name, and email.  
- `ActivityDeletionRequestAdmin`:  
  - Bulk approve/reject requests.  
  - `list_display`, filters, and read-only `requested_at`.  

### `activities/views.py`
- `get_queryset` scoped by **organizer organization**.  
- Permission checks validate **same-organization access**.  

---

## API Behavior  

### Organizer Flow
- `GET /api/activities/` → lists **all activities for the organizer’s organization**.  
- `DELETE /api/activities/{id}/` →  
  - `204 No Content` if `current_participants == 0`.  
  - `409 Conflict` if `current_participants > 0`.  
- `POST /api/activities/{id}/request-delete` with `{ "reason": "..." }` → `201 Created`.  

### Admin Flow
- `GET /api/activities/deletion-requests/` → list pending requests.  
- `POST /api/activities/deletion-requests/{request_id}/review/` with:  
  ```json
  { "action": "approve" | "reject", "note": "..." }
### Sample request
- Login (example)
`curl -X POST http://localhost:8000/api/auth/login/ \
  -H "Content-Type: application/json" \
  -d '{ "email": "<organizer_email>", "password": "<password>" }'`
- Request deletion
`curl -X POST http://localhost:8000/api/activities/{id}/request-delete/ \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{ "reason": "Event cancelled due to weather" }'`
