### PR TITLE
Implement admin approve and reject

### DIFF
--- a/backend/activities/models.py
+++ b/backend/activities/models.py
@@ -42,6 +42,8 @@ class Activity(models.Model):
         blank=True, 
         validators=[MinValueValidator(0)]
     )
+    # Reason provided by admin when an activity is rejected in moderation
+    rejection_reason = models.TextField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/activities/serializers.py
+++ b/backend/activities/serializers.py
@@ -14,11 +14,11 @@ class ActivitySerializer(serializers.ModelSerializer):
         fields = [
             'id', 'organizer_profile_id', 'organizer_email', 'organizer_name', 'categories', 'title', 'description',
             'start_at', 'end_at', 'location', 'max_participants', 'current_participants',
-            'status', 'hours_awarded', 'created_at', 'updated_at', 'requires_admin_for_delete', 'capacity_reached',
+            'status', 'hours_awarded', 'rejection_reason', 'created_at', 'updated_at', 'requires_admin_for_delete', 'capacity_reached',
         ]
         read_only_fields = [
             'id', 'organizer_profile_id', 'organizer_email', 'organizer_name', 'current_participants', 'status',
-            'created_at', 'updated_at', 'requires_admin_for_delete', 'capacity_reached'
+            'rejection_reason', 'created_at', 'updated_at', 'requires_admin_for_delete', 'capacity_reached'
         ]
 
 
@@ -48,5 +48,4 @@ class ActivityDeletionRequestSerializer(serializers.ModelSerializer):
             'requested_at', 'reviewed_by', 'reviewed_at', 'review_note'
         ]
         read_only_fields = ['status', 'requested_at', 'reviewed_by', 'reviewed_at']
-
 

--- a/backend/activities/urls.py
+++ b/backend/activities/urls.py
@@ -9,6 +9,8 @@ from .views import (
     ActivityDeletionRequestListView,
     ActivityDeletionRequestReviewView,
     ActivityMetadataView,
+    ActivityModerationListView,
+    ActivityModerationReviewView,
 )
 
 
@@ -25,4 +27,7 @@ urlpatterns = [
     path('deletion-requests/<int:pk>/review/', ActivityDeletionRequestReviewView.as_view(), name='activity-deletion-request-review'),
     # Metadata for categories
     path('metadata/', ActivityMetadataView.as_view(), name='activity-metadata'),
+    # Admin moderation of activities
+    path('moderation/pending/', ActivityModerationListView.as_view(), name='activity-moderation-list'),
+    path('moderation/<int:pk>/review/', ActivityModerationReviewView.as_view(), name='activity-moderation-review'),
 ]

--- a/backend/config/constants.py
+++ b/backend/config/constants.py
@@ -21,6 +21,7 @@ class ActivityStatus:
     FULL = 'full'
     CLOSED = 'closed'
     CANCELLED = 'cancelled'
+    REJECTED = 'rejected'
     
     CHOICES = [
         (PENDING, 'Pending'),
@@ -28,6 +29,7 @@ class ActivityStatus:
         (FULL, 'Full'),
         (CLOSED, 'Closed'),
         (CANCELLED, 'Cancelled'),
+        (REJECTED, 'Rejected'),
     ]
 
 # Organization types


### PR DESCRIPTION
## Description
This PR adds an admin moderation flow for newly created activities.
When an organization creates an activity, it starts in status pending. Admins can now approve or reject activities. If rejected, a reason is required and stored on the activity.

---

## What Changed
Activity Moderation (Admin)

**New admin-only endpoints:**
-  `GET /api/activities/moderation/pending/` — list all `pending` activities
- `POST /api/activities/moderation/{id}/review/` — approve/reject an activity
- Approve → [status: open](clears any previous rejection reason)
- Reject → [status: rejected]and requires non-empty "reason"

---

## Checklist

- [x] Admin can list pending activities
- [x] Admin can approve a pending activity → status becomes open
- [x] Admin can reject a pending activity → status becomes rejected
- [x] Rejecting requires a non-empty reason
- [x] [rejection_reason]is persisted and included in activity responses
- [x] URLs added for moderation list and review

---

## ScreenShot

- admin approve activities status will turn from pending to Open

<img width="647" height="678" alt="Screenshot 2568-10-02 at 19 31 36" src="https://github.com/user-attachments/assets/4bbc834f-49e3-4f04-8795-6a3a7350c0e9" />

- admin rejected with reason status will turn from pending to Rejected

<img width="682" height="607" alt="Screenshot 2568-10-02 at 19 31 58" src="https://github.com/user-attachments/assets/0c6974fc-91d7-4509-9410-5eb77b0ef13d" />

- pending to Rejected

<img width="702" height="545" alt="Screenshot 2568-10-02 at 19 32 18" src="https://github.com/user-attachments/assets/e869eb4b-713a-4c44-a81e-08335ffa2435" />

- pending to open

<img width="658" height="464" alt="Screenshot 2568-10-02 at 19 32 27" src="https://github.com/user-attachments/assets/e9ee9457-872b-4418-87e0-3a0018ccc026" />

# Backend Changes

## views.py
- **Added**
  - `ActivityModerationListView`: Admin-only list for pending activities.
  - `ActivityModerationReviewView`: Admin-only approve/reject endpoint.
    - Enforces providing a reason on rejection.
    - Updates status and `rejection_reason`.

- **Updated**
  - `ActivityDeletionRequestReviewView`: Rejecting a deletion request now requires a non-empty note.

---

## urls.py
- **Added Routes**
  - `GET moderation/pending/` → `ActivityModerationListView`
  - `POST moderation/<int:pk>/review/` → `ActivityModerationReviewView`

---

## models.py
- **Activity Model**
  - Added field:
    ```python
    rejection_reason = models.TextField(blank=True, null=True)
    ```

---

## serializers.py
- **ActivitySerializer**
  - Added `rejection_reason` (read-only) to fields list.

---

## constants.py
- **ActivityStatus**
  - Added `REJECTED`
  - Appended to `status` choices.

# API Behavior

## Admin Flow

### List pending activities
`GET /api/activities/moderation/pending/`

### Moderate a pending activity
**Approve:**
`POST /api/activities/moderation/{id}/review/`
`Body: { "action": "approve" }`
`Result: activity status → open`

**Reject (reason required):**
`POST /api/activities/moderation/{id}/review/`
`Body: { "action": "reject", "reason": "Overlaps with another university-wide event" }`
`Result: activity status → rejected, rejection_reason set`

## Deletion Request Review (Admin)
Reject requires a non-empty note:
`POST /api/activities/deletion-requests/{request_id}/review/`
`Body: { "action": "reject", "note": "Participants still need this event" }`
